### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :set_select_box_values, only: [:new, :create, :edit, :update]
-  before_action :redirect_if_not_owner, only: [:edit, :update]
+  before_action :redirect_if_not_owner, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.includes(:image_attachment).order(created_at: :desc)
@@ -39,6 +39,16 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path, notice: "商品を削除しました"
+    else
+      redirect_to root_path
+    end
+  end
+  
+  
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,12 +40,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user_id == current_user.id
       @item.destroy
       redirect_to root_path, notice: "商品を削除しました"
-    else
-      redirect_to root_path
-    end
   end
   
   

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,9 @@
   <% if current_user == @item.user %>
     <!-- 出品者：編集・削除ボタン -->
    <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-    <%= link_to "削除",  "#", class: "item-destroy" %>
+    <%= button_to "削除", item_path(@item), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+
+
   <% else %>
     <!-- 出品者以外のログインユーザー：購入ボタン -->
     <%= link_to "購入画面に進む",  "#", class: "item-red-btn" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,8 @@
   <% if current_user == @item.user %>
     <!-- 出品者：編集・削除ボタン -->
    <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-    <%= button_to "削除", item_path(@item), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: { turbo_method: :delete, confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+
 
 
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,5 @@ Rails.application.routes.draw do
   root 'items#index'
 
   # 必要なアクションをまとめて1行に定義
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
-
+  resources :items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   root 'items#index'
 
   # 必要なアクションをまとめて1行に定義
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+
 end


### PR DESCRIPTION
What
商品詳細ページの削除ボタンを link_to から button_to に変更しました。

Why
link_to に method: :delete を指定しても、JavaScriptが有効でなければ DELETE メソッドが送信されず、削除機能が正常に動作しないため。

・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/936cb4693819fd54df6cd95fa53f047e